### PR TITLE
Remove couch_crypto

### DIFF
--- a/src/oauth.erl
+++ b/src/oauth.erl
@@ -128,7 +128,7 @@ hmac_sha1_signature(HttpMethod, URL, Params, Consumer, TokenSecret) ->
 
 hmac_sha1_signature(BaseString, Consumer, TokenSecret) ->
   Key = uri_join([consumer_secret(Consumer), TokenSecret]),
-  base64:encode_to_string(couch_crypto:hmac(sha, Key, BaseString)).
+  base64:encode_to_string(crypto:hmac(sha, Key, BaseString)).
 
 hmac_sha1_verify(Signature, HttpMethod, URL, Params, Consumer, TokenSecret) ->
   verify_in_constant_time(Signature, hmac_sha1_signature(HttpMethod, URL, Params, Consumer, TokenSecret)).


### PR DESCRIPTION
The crypto:hmac function exists in all the versions of erlang supported by CouchDB.